### PR TITLE
Add OS-conditional sed command

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -25,13 +25,18 @@ currentyear=$(date +"%Y")
 echo "Running template-haskell Haskell project generator wizard"
 
 echo "Substituting placeholder variables..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SED_CMD="sed -i ''"
+else
+    SED_CMD="sed -i"
+fi
 (
     set -x
-    git ls-files | xargs -I _ sed _ -i \
-        -e "s#PKGNAME#$PKGNAME#g" \
-        -e "s#AUTHNAME#$AUTHNAME#g" \
-        -e "s#EMAIL#$EMAIL#g" \
-        -e "s#CURRENTYEAR#$currentyear#g"
+    git ls-files | xargs -I _ sh -c " $SED_CMD \
+        -e 's#PKGNAME#$PKGNAME#g' \
+        -e 's#AUTHNAME#$AUTHNAME#g' \
+        -e 's#EMAIL#$EMAIL#g' \
+        -e 's#CURRENTYEAR#$currentyear#g' _"
 ) 2>&1 | indent
 
 echo "Renaming files..."


### PR DESCRIPTION
This repo is super helpful! Here is a tiny PR.

Resolves #19 - updates `wizard.sh` to have a OS-dependent sed command (currently just Darwin vs other. Other is assumed to be Linux).

There are a couple of other modifications to ensure escaping works for this new command.

Tested on my x86_64-linux and M2 aarch64-darwin laptops.